### PR TITLE
feat: Added oha for loading tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,10 @@ RUN wget -O go.tar.gz $GO_URL && \
     tar -C /usr/local -xzf go.tar.gz && \
     rm go.tar.gz
 
+# Download and install oha
+RUN wget -qO /usr/local/bin/oha https://github.com/hatoo/oha/releases/latest/download/oha-linux-${TARGETARCH} && \
+    chmod +x /usr/local/bin/oha
+
 # Set Go path
 ENV PATH="/usr/local/go/bin:${PATH}"
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The Docker image includes the following tools:
 - `postgresql-client`
 - **Go** (installed minimally)
 - `nginx`
+- `oha`
 
 ## Getting Started
 


### PR DESCRIPTION
Add installation of oha to Dockerfile

- Download oha from the latest release based on target architecture
- Set executable permissions for oha

- Motivation and Context

Add oha installation to Dockerfile for HTTP benchmarking

- Download oha from the latest release based on target architecture
- Set executable permissions for oha
- Enhance the Docker image with a tool for HTTP load testing and benchmarking

-  How Has This Been Tested?

podman run --rm quay.io/skupper/lanyard:latest oha

-  Types of Changes

- [ ] Bug fix
- [X] New feature
- [X] Documentation change
- [ ] Other (please specify):

-  Checklist:

-- [X] My code follows the style guidelines of this project -- [X] I have performed a self-review of my own code -- [X] I have commented my code, particularly in hard-to-understand areas -- [X] I have made corresponding changes to the documentation -- [X] My changes generate no new warnings
-- [X] I have added tests that prove my fix is effective or that my feature works -- [X] New and existing unit tests pass locally with my changes