### PR TITLE
Enabling Power arch for lanyard

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Build and Push Multi-Arch Image
         run: |
           docker buildx build \
-            --platform linux/amd64,linux/arm64,linux/s390x \
+            --platform linux/amd64,linux/arm64,linux/s390x,linux/ppc64le \
             -t quay.io/skupper/lanyard:latest \
             --push .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apk update && apk add --no-cache \
   postgresql15-client \
   redis \
   nginx && \
-  if [ "$TARGETOS" = "linux" ] && [ [ "$TARGETARCH" = "amd64" ] || [ "$TARGETARCH" = "arm64" ] ]; then \
+  if [ "$TARGETOS" = "linux" ] && [ "$TARGETARCH" != "s390x" ] && [ "$TARGETARCH" != "ppc64le" ]; then \
     apk add --no-cache mongodb-tools && \
     wget -qO /usr/local/bin/oha https://github.com/hatoo/oha/releases/latest/download/oha-linux-${TARGETARCH} && \
     chmod +x /usr/local/bin/oha; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apk update && apk add --no-cache \
   postgresql15-client \
   redis \
   nginx && \
-  if [ "$TARGETOS" = "linux" ] && [ "$TARGETARCH" != "s390x" ]; then \
+  if [ "$TARGETOS" = "linux" ] && { [ "$TARGETARCH" = "amd64" ] || [ "$TARGETARCH" = "arm64" ]; }; then \
     apk add --no-cache mongodb-tools && \
     wget -qO /usr/local/bin/oha https://github.com/hatoo/oha/releases/latest/download/oha-linux-${TARGETARCH} && \
     chmod +x /usr/local/bin/oha; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN apk update && apk add --no-cache \
   postgresql15-client \
   redis \
   nginx && \
-  if [ "$TARGETOS" = "linux" ] && { [ "$TARGETARCH" = "amd64" ] || [ "$TARGETARCH" = "arm64" ]; }; then \
+  if [ "$TARGETOS" = "linux" ] && [ [ "$TARGETARCH" = "amd64" ] || [ "$TARGETARCH" = "arm64" ] ]; then \
     apk add --no-cache mongodb-tools && \
     wget -qO /usr/local/bin/oha https://github.com/hatoo/oha/releases/latest/download/oha-linux-${TARGETARCH} && \
     chmod +x /usr/local/bin/oha; \


### PR DESCRIPTION
- Enabling Power arch for lanyard build.
- Updated Dockerfile to support only linux/amd64 & linux/arm64 for extra packages.
- Enabled the power arch for multi-arch build in git workflow.

I'm verifying Skupper on Power for [MULTIARCH-5587](https://issues.redhat.com/browse/MULTIARCH-5587)

CC: @prb112, @[mjturek@us.ibm.com](mailto:mjturek@us.ibm.com) & @hash-d 